### PR TITLE
[ASSIGNMENTS] Fix IPYNB: add space after '##', remove space after '$$'

### DIFF
--- a/markdown/assignments/files/logistische_regression_starter.ipynb
+++ b/markdown/assignments/files/logistische_regression_starter.ipynb
@@ -6,7 +6,7 @@
         "id": "lKZ4-E_ycsFE"
       },
       "source": [
-        "#Logistic Regression from a Neural Network Point of View \n",
+        "# Logistic Regression from a Neural Network Point of View \n",
         "\n",
         "(Starter Code)"
       ]
@@ -17,7 +17,7 @@
         "id": "5w6Y_5fmf2eM"
       },
       "source": [
-        "##**1 - Imports**"
+        "## **1 - Imports**"
       ]
     },
     {
@@ -47,7 +47,7 @@
         "id": "JKSLABRTcsFW"
       },
       "source": [
-        "##**2 - `sklearn` Dataset & Preprocessing**\n",
+        "## **2 - `sklearn` Dataset & Preprocessing**\n",
         "\n",
         "Input, Output: X1_, Y1_\n",
         "\n",
@@ -205,7 +205,7 @@
         "id": "vcUR0ORbeqhA"
       },
       "source": [
-        "##**3 - Using LogisticRegression of sklearn**\n",
+        "## **3 - Using LogisticRegression of sklearn**\n",
         "\n",
         "\n",
         "\n",
@@ -215,11 +215,11 @@
         "\n",
         "\n",
         "**The Loss**\n",
-        "$$ \\mathcal{L}(a, y) =  - y  \\log(a) - (1-y)  \\log(1-a)\\tag{3}$$\n",
+        "$$\\mathcal{L}(a, y) =  - y  \\log(a) - (1-y)  \\log(1-a)\\tag{3}$$\n",
         "\n",
         "\n",
         "**The Cost is the average loss over all examples $x^{(i)} ... x^{(m)}$**\n",
-        "$$ J = \\frac{1}{m} \\sum_{i=1}^m \\mathcal{L}(a^{(i)}, y^{(i)})\\tag{4}$$\n"
+        "$$J = \\frac{1}{m} \\sum_{i=1}^m \\mathcal{L}(a^{(i)}, y^{(i)})\\tag{4}$$\n"
       ]
     },
     {
@@ -411,7 +411,7 @@
         "id": "4NFz-HAQDDX6"
       },
       "source": [
-        "##**4 - Implement your functions**\n",
+        "## **4 - Implement your functions**\n",
         "\n",
         "Complete the function implementations below. Replace the \"None\" instances with your code."
       ]
@@ -422,7 +422,7 @@
         "id": "W3kXcODkrt4i"
       },
       "source": [
-        "###**Parameter Initialization**\n",
+        "### **Parameter Initialization**\n",
         "\n"
       ]
     },
@@ -450,7 +450,7 @@
         "id": "E-k_s0hUqWxF"
       },
       "source": [
-        "###**One Forward Pass**\n",
+        "### **One Forward Pass**\n",
         "$A = \\sigma(w^T X) = (a^{(1)}, a^{(2)}, ..., a^{(m-1)}, a^{(m)})$"
       ]
     },
@@ -478,7 +478,7 @@
         "id": "PqIvXF8RuNuc"
       },
       "source": [
-        "###**Calculating the Loss (Cross-Entropy Loss)**\n",
+        "### **Calculating the Loss (Cross-Entropy Loss)**\n",
         "\n",
         "$$\\mathcal{L}(A,Y) = -Y\\log(A)-(1-Y)\\log(1-A)\\tag{5}$$"
       ]
@@ -507,13 +507,14 @@
         "id": "VpbSm3FurJN7"
       },
       "source": [
-        "###**Calculating the Cost**\n",
+        "### **Calculating the Cost**\n",
         "\n",
         "Averaging over the Losses: \n",
         "\n",
-        "$$ J = \\frac{1}{m} np.sum(L)\\tag{6}$$\n",
-        "<br>\n",
-        "$$ J(A,Y) = \\frac{1}{m}np.sum(-Y\\log(A)-(1-Y)\\log(1-A))\\tag{7}$$"
+        "$$J = \\frac{1}{m} np.sum(L)\\tag{6}$$\n",
+        "\n",
+        "\n",
+        "$$J(A,Y) = \\frac{1}{m}np.sum(-Y\\log(A)-(1-Y)\\log(1-A))\\tag{7}$$"
       ]
     },
     {
@@ -543,9 +544,9 @@
         "id": "a8JcRyZPvr0b"
       },
       "source": [
-        "###**Calculating the Gradients**\n",
+        "### **Calculating the Gradients**\n",
         "\n",
-        "$$ dw := \\frac{\\partial J}{\\partial w} = \\frac{1}{m}X(A-Y)^T\\tag{8}$$\n"
+        "$$dw := \\frac{\\partial J}{\\partial w} = \\frac{1}{m}X(A-Y)^T\\tag{8}$$\n"
       ]
     },
     {
@@ -572,9 +573,9 @@
         "id": "rvf3osxSqxVP"
       },
       "source": [
-        "###**One Optimization/Learning Step**\n",
+        "### **One Optimization/Learning Step**\n",
         "\n",
-        "$$ w = w - \\alpha \\ dw\\tag{10}$$"
+        "$$w = w - \\alpha \\ dw\\tag{10}$$"
       ]
     },
     {
@@ -601,7 +602,7 @@
         "id": "RwmKzQT47TdU"
       },
       "source": [
-        "##**4 - One training step**\n",
+        "## **4 - One training step**\n",
         "\n",
         "Test your functions"
       ]
@@ -730,7 +731,7 @@
         "id": "Ud_l_AGH6U1k"
       },
       "source": [
-        "##**5 - Gradient Descent**\n",
+        "## **5 - Gradient Descent**\n",
         "\n",
         "Train a logistic regression model, i.e. optimize the parameters"
       ]


### PR DESCRIPTION
Dieser PR behebt Darstellungsprobleme in den Jupyter-Notebooks für die Aufgaben:

- Hinter den `##` für die Überschriften muss ein Leerzeichen kommen
- Hinter den `$$` für die Formelumgebung darf kein Leerzeichen kommen

@cyildiz Kannst Du bitte kurz schauen, ob ich damit jetzt nichts kaputt mache? Im Github wurde das teilweise korrekt angezeigt, aber eben in VSCode hat das nicht gut funktioniert. Dieser Fix sollte das beheben und sowohl in VSCode als auch in Github funktionieren :)