### PR TITLE
markdown: replace 'operatorname' w/ mathop+text (workaround gh bug)

### DIFF
--- a/admin/exams-hsbi.md
+++ b/admin/exams-hsbi.md
@@ -269,8 +269,8 @@ Lerntabelle an.
 
 Anders als in der Vorlesung besprochen, sollen die Gewichte $w_1$ und $w_2$ sowie
 die Schwelle $\theta$ jeweils mit dem Wert $0$ initialisiert werden. Die
-Lernschrittweite $\alpha$ sei $0.5$. Nutzen Sie die $\operatorname{sign}$-Funktion
-als Aktivierungsfunktion: $$\operatorname{sign}(x) = \left\{
+Lernschrittweite $\alpha$ sei $0.5$. Nutzen Sie die $\mathop{\text{sign}}$-Funktion
+als Aktivierungsfunktion: $$\mathop{\text{sign}}(x) = \left\{
     \begin{array}{ll}
     0 & \text{falls } x<0\\
     1 & \text{sonst}

--- a/homework/sheet-nn-mlp.md
+++ b/homework/sheet-nn-mlp.md
@@ -9,7 +9,7 @@ title: "Übungsblatt: Overfitting & MLP"
 
 Konstruieren Sie ein Netz mit drei Perzeptrons, welches für zwei Eingabevariablen
 $x_1$ und $x_2$ die in der folgenden Abbildung blau-grau dargestellten Bereiche mit
-+1 klassifiziert. Benutzen Sie die $\operatorname{sign}$-Funktion als
++1 klassifiziert. Benutzen Sie die $\mathop{\text{sign}}$-Funktion als
 Aktivierungsfunktion.
 
 ![Abbildung 1](images/perzeptron_netz.png){width="60%"}

--- a/lecture/csp/csp1-intro.md
+++ b/lecture/csp/csp1-intro.md
@@ -50,8 +50,8 @@ Länder müssen unterschiedliche Farben bekommen (=\> *Constraint*).
 \smallskip
 
 -   **Mögliche Lösung**: Zuweisung an Variablen ("Belegung")
-    $\lbrace \operatorname{A} = red, \operatorname{B} = blue, \operatorname{C} = green,
-    \operatorname{D} = red, \operatorname{E} = blue, \operatorname{F} = blue \rbrace$
+    $\lbrace \mathop{\text{A}} = red, \mathop{\text{B}} = blue, \mathop{\text{C}} = green,
+    \mathop{\text{D}} = red, \mathop{\text{E}} = blue, \mathop{\text{F}} = blue \rbrace$
 
 # Definition: Constraint Satisfaction Problem (CSP)
 
@@ -93,12 +93,12 @@ Constraint miteinander in Beziehung? (Also wie viele Parameter hat ein Constrain
 :::
 
 -   **unär**: betrifft einzelne Variablen `\newline`{=tex} Beispiel:
-    $\operatorname{A} \neq red$
+    $\mathop{\text{A}} \neq red$
 
 \smallskip
 
 -   **binär**: betrifft Paare von Variablen `\newline`{=tex} Beispiel:
-    $\operatorname{A} \neq \operatorname{B}$
+    $\mathop{\text{A}} \neq \mathop{\text{B}}$
 
 \smallskip
 

--- a/lecture/dtl/dtl1-mlbasics.md
+++ b/lecture/dtl/dtl1-mlbasics.md
@@ -123,17 +123,17 @@ ausgewählte Beispielobjekte (durch Merkmalsvektoren beschrieben) plus die Vorga
 
 -   **Gesucht**: Diagnose und Reparaturanleitung
 
-    =\> Hypothese über den Merkmalen (Funktion $\operatorname{h}$)
+    =\> Hypothese über den Merkmalen (Funktion $\mathop{\text{h}}$)
 
-# Lernen durch Beobachten: Lernen einer Funktion $\operatorname{f}$
+# Lernen durch Beobachten: Lernen einer Funktion $\mathop{\text{f}}$
 
 ::: notes
-Funktionsapproximation: Lernen einer Funktion $\operatorname{f}$ anhand von
+Funktionsapproximation: Lernen einer Funktion $\mathop{\text{f}}$ anhand von
 Beispielen
 :::
 
--   Ein Beispiel ist ein Tupel $(\mathbf{x}, \operatorname{f}(\mathbf{x}))$, etwa
-    $$(\mathbf{x}, \operatorname{f}(\mathbf{x})) = \left(\begin{array}{ccc}
+-   Ein Beispiel ist ein Tupel $(\mathbf{x}, \mathop{\text{f}}(\mathbf{x}))$, etwa
+    $$(\mathbf{x}, \mathop{\text{f}}(\mathbf{x})) = \left(\begin{array}{ccc}
     O & O & X \\
     . & X & . \\
     X & . & .
@@ -141,8 +141,8 @@ Beispielen
 
 \bigskip
 
--   Aufgabe: Baue Hypothese $\operatorname{h}$ auf, so dass
-    $\operatorname{h} \approx \operatorname{f}$.
+-   Aufgabe: Baue Hypothese $\mathop{\text{h}}$ auf, so dass
+    $\mathop{\text{h}} \approx \mathop{\text{f}}$.
     -   Benutze dazu Menge von Beispielen =\> **Trainingsdaten**.
 
 \bigskip
@@ -233,7 +233,7 @@ den Zusammenhang zwischen den Daten! Dies ist in der Regel unerwünscht!
 # Trainingsdaten und Merkmalsvektoren
 
 Lehrer gibt Beispiele vor: Eingabe $\mathbf{x}$ und passende Ausgabe
-$\operatorname{f}(\mathbf{x})$
+$\mathop{\text{f}}(\mathbf{x})$
 
 \smallskip
 

--- a/lecture/dtl/dtl5-entropy.md
+++ b/lecture/dtl/dtl5-entropy.md
@@ -92,9 +92,9 @@ Entropie: $H(V) = -\sum_k p_k \log_2 p_k$
 
 ::::: columns
 ::: {.column width="75%"}
--   $v_1 = \operatorname{Kopf},  v_2 = \operatorname{Zahl}$
+-   $v_1 = \mathop{\text{Kopf}},  v_2 = \mathop{\text{Zahl}}$
 -   $p_1 = 0.5,  p_2 = 0.5$
--   $H(\operatorname{Fair}) = -(0.5 \log_2 0.5 + 0.5 \log_2 0.5) = 1$ Bit
+-   $H(\mathop{\text{Fair}}) = -(0.5 \log_2 0.5 + 0.5 \log_2 0.5) = 1$ Bit
 :::
 
 ::: {.column width="25%"}
@@ -115,13 +115,13 @@ Entropie: $H(V) = -\sum_k p_k \log_2 p_k$
 ::: {.column width="75%"}
 \pause
 
--   $v_1 = \operatorname{Kopf},  v_2 = \operatorname{Zahl}$
+-   $v_1 = \mathop{\text{Kopf}},  v_2 = \mathop{\text{Zahl}}$
 
 -   $p_1 = 0.99,  p_2 = 0.01$
 
--   $H(\operatorname{UnFair}) = -(0.99 \log_2 0.99 + 0.01 \log_2 0.01)$
+-   $H(\mathop{\text{UnFair}}) = -(0.99 \log_2 0.99 + 0.01 \log_2 0.01)$
 
-    $H(\operatorname{UnFair}) \approx 0.08$ Bit
+    $H(\mathop{\text{UnFair}}) \approx 0.08$ Bit
 :::
 
 ::: {.column width="25%"}
@@ -146,7 +146,7 @@ Entropie: $H(V) = -\sum_k p_k \log_2 p_k$
 
 -   $v_1 = 1,  v_2 = 2,   v_3 = 3,   v_4 = 4$
 -   $p_1 = p_2 = p_3 = p_4 = 0.25$
--   $H(\operatorname{Wuerfel}) = -4\cdot(0.25 \log_2 0.25) = 2$ Bit
+-   $H(\mathop{\text{Wuerfel}}) = -4\cdot(0.25 \log_2 0.25) = 2$ Bit
 :::
 
 ::: {.column width="25%"}
@@ -187,14 +187,14 @@ Wahrscheinlichkeit für $B$: $p_B = 2/6 = 0.333$
 $$\begin{eqnarray}
     H(S) &=& -\sum_k p_k \log_2 p_k\\
          &=& -(4/6 \cdot \log_2 4/6 + 2/6 \cdot \log_2 2/6)\\
-         &=& -(-0.39 -0.53) = 0.92 \operatorname{Bit}
+         &=& -(-0.39 -0.53) = 0.92 \mathop{\text{Bit}}
 \end{eqnarray}$$
 
 # Mittlere Entropie nach Betrachtung von Attribut $A$
 
 \large
 
-$$    R(S, A) = \sum_{v \in \operatorname{Values}(A)} \frac{|S_v|}{|S|} H(S_v)$$
+$$    R(S, A) = \sum_{v \in \mathop{\text{Values}}(A)} \frac{|S_v|}{|S|} H(S_v)$$
 
 \normalsize
 
@@ -237,11 +237,11 @@ $$    R(S, A) = \sum_{v \in \operatorname{Values}(A)} \frac{|S_v|}{|S|} H(S_v)$$
 \pause
 
 $$\begin{eqnarray}
-    R(S, A) &=& \sum_{v \in \operatorname{Values}(A)} \frac{|S_v|}{|S|} H(S_v)\\
+    R(S, A) &=& \sum_{v \in \mathop{\text{Values}}(A)} \frac{|S_v|}{|S|} H(S_v)\\
          &=& 4/6 \cdot H(\lbrace 1,3,5,6 \rbrace) + 2/6 \cdot H(\lbrace 2,4 \rbrace)\\
          &=& 4/6\cdot(-3/4 \cdot \log_2 3/4 - 1/4 \cdot \log_2 1/4) +\\
          && 2/6\cdot(-1/2 \cdot \log_2 1/2 - 1/2 \cdot \log_2 1/2)\\
-         &=& 0.54 + 0.33 = 0.87 \operatorname{Bit}
+         &=& 0.54 + 0.33 = 0.87 \mathop{\text{Bit}}
 \end{eqnarray}$$
 
 ::: notes

--- a/lecture/dtl/dtl6-id3.md
+++ b/lecture/dtl/dtl6-id3.md
@@ -40,15 +40,15 @@ Erinnerung: CAL2/CAL3
 
 -   Mittlere Entropie nach Betrachtung von Attribut $A$
 
-    $$    R(S, A) = \sum_{v \in \operatorname{Values}(A)} \frac{|S_v|}{|S|} H(S_v)$$
+    $$    R(S, A) = \sum_{v \in \mathop{\text{Values}}(A)} \frac{|S_v|}{|S|} H(S_v)$$
 
 \bigskip
 
 -   Informationsgewinn durch Betrachtung von Attribut $A$
 
     $$\begin{eqnarray}
-        \operatorname{Gain}(S, A) &=& H(S) - R(S, A)\\[5pt]
-                                &=& H(S) - \sum_{v \in \operatorname{Values}(A)} \frac{|S_v|}{|S|} H(S_v)
+        \mathop{\text{Gain}}(S, A) &=& H(S) - R(S, A)\\[5pt]
+                                &=& H(S) - \sum_{v \in \mathop{\text{Values}}(A)} \frac{|S_v|}{|S|} H(S_v)
     \end{eqnarray}$$
 
 ::: notes
@@ -81,14 +81,14 @@ Betrachtung von Attribut $A$ ...
 \vspace{8mm}
 \small
 
-$H(S) = 0.92 \operatorname{Bit}$
+$H(S) = 0.92 \mathop{\text{Bit}}$
 
 $$\begin{eqnarray}
-\operatorname{Gain}(S, x_1) &=& 0.92 - 0.87 = 0.05 \operatorname{Bit}\\
-\operatorname{Gain}(S, x_2) &=& 0.92 - 2/6  \cdot 0 - 4/6 \cdot 1\\
-                            &=& 0.25 \operatorname{Bit}\\
-\operatorname{Gain}(S, x_3) &=& 0.92 - 3/6 \cdot 0.92 - 2/6 \cdot 1 - 1/6 \cdot 0\\
-                            &=& 0.13 \operatorname{Bit}
+\mathop{\text{Gain}}(S, x_1) &=& 0.92 - 0.87 = 0.05 \mathop{\text{Bit}}\\
+\mathop{\text{Gain}}(S, x_2) &=& 0.92 - 2/6  \cdot 0 - 4/6 \cdot 1\\
+                            &=& 0.25 \mathop{\text{Bit}}\\
+\mathop{\text{Gain}}(S, x_3) &=& 0.92 - 3/6 \cdot 0.92 - 2/6 \cdot 1 - 1/6 \cdot 0\\
+                            &=& 0.13 \mathop{\text{Bit}}
 \end{eqnarray}$$
 
 \normalsize
@@ -124,8 +124,8 @@ def ID3(examples, attr, default):
 ::: notes
 @Russell2020: Man erhält aus dem "Learn-Decision-Tree"-Algorithmus [@Russell2020, S.
 678, Fig. 19.5] den hier vorgestellten ID3-Algorithmus, wenn man die Funktion
-$\operatorname{Importance}(a, examples)$ als
-$\operatorname{InformationGain}(examples, attr)$ implementiert/nutzt.
+$\mathop{\text{Importance}}(a, examples)$ als
+$\mathop{\text{InformationGain}}(examples, attr)$ implementiert/nutzt.
 
 **Hinweis**: Mit der Zeile `if examples.each(class == A):  return A` soll
 ausgedrückt werden, dass alle ankommenden Trainingsbeispiele die selbe Klasse haben
@@ -154,21 +154,21 @@ Klassensymbol als "`A`" sein ...
 
 [[Tafelbeispiel Anfang ID3]{.ex}]{.slides}
 
-# Beobachtung: $\operatorname{Gain}$ ist bei mehrwertigen Attributen höher
+# Beobachtung: $\mathop{\text{Gain}}$ ist bei mehrwertigen Attributen höher
 
 -   Faire Münze:
     -   Entropie =
-        $H(\operatorname{Fair}) = -(0.5 \log_2 0.5 + 0.5 \log_2 0.5) = 1 \operatorname{Bit}$
+        $H(\mathop{\text{Fair}}) = -(0.5 \log_2 0.5 + 0.5 \log_2 0.5) = 1 \mathop{\text{Bit}}$
 
 \smallskip
 
 -   4-seitiger Würfel:
     -   Entropie =
-        $H(\operatorname{Dice}) = -4\cdot(0.25 \log_2 0.25) = 2 \operatorname{Bit}$
+        $H(\mathop{\text{Dice}}) = -4\cdot(0.25 \log_2 0.25) = 2 \mathop{\text{Bit}}$
 
 \bigskip
 
-=\> $\operatorname{Gain}$ ist bei mehrwertigen Attributen höher
+=\> $\mathop{\text{Gain}}$ ist bei mehrwertigen Attributen höher
 
 ::: notes
 Damit würden Attribute bei der Wahl bevorzugt, nur weil sie mehr Ausprägungen haben
@@ -176,7 +176,7 @@ als andere.
 
 *Anmerkung*: Im obigen Beispiel wurde einfach die Entropie für zwei "Attribute" mit
 unterschiedlich vielen Ausprägungen betrachtet, das ist natürlich kein
-$\operatorname{Gain}(S, A)$. Aber es sollte deutlich machen, dass Merkmale mit mehr
+$\mathop{\text{Gain}}(S, A)$. Aber es sollte deutlich machen, dass Merkmale mit mehr
 Ausprägungen bei der Berechnung des Gain für eine Trainingsmenge einfach wegen der
 größeren Anzahl an Ausprägungen rechnerisch bevorzugt würden.
 :::
@@ -184,10 +184,10 @@ größeren Anzahl an Ausprägungen rechnerisch bevorzugt würden.
 # C4.5 als Verbesserung zu ID3
 
 Normierter Informationsgewinn:
-$\operatorname{Gain}(S, A) \cdot \operatorname{Normalisation}(A)$
+$\mathop{\text{Gain}}(S, A) \cdot \mathop{\text{Normalisation}}(A)$
 
-$$    \operatorname{Normalisation}(A) = \frac{1}{
-        \sum_{v \in \operatorname{Values}(A)} p_v \log_2 \frac{1}{p_v}
+$$    \mathop{\text{Normalisation}}(A) = \frac{1}{
+        \sum_{v \in \mathop{\text{Values}}(A)} p_v \log_2 \frac{1}{p_v}
     }$$
 
 ::: notes
@@ -222,28 +222,28 @@ Hierzu drei lesenswerte Blog-Einträge:
 
 -   Faire Münze:
     -   Entropie =
-        $H(\operatorname{Fair}) = -(0.5 \log_2 0.5 + 0.5 \log_2 0.5) = 1 \operatorname{Bit}$
+        $H(\mathop{\text{Fair}}) = -(0.5 \log_2 0.5 + 0.5 \log_2 0.5) = 1 \mathop{\text{Bit}}$
     -   Normierung:
         $1/(0.5 \log_2 (1/0.5) + 0.5 \log_2 (1/0.5)) = 1/(0.5 \cdot 1 + 0.5 \cdot 1) = 1$
     -   Normierter Informationsgewinn:
-        $\operatorname{Gain}(S, A) \cdot \operatorname{Normalisation}(A) = 1 \operatorname{Bit} \cdot 1 = 1 \operatorname{Bit}$
+        $\mathop{\text{Gain}}(S, A) \cdot \mathop{\text{Normalisation}}(A) = 1 \mathop{\text{Bit}} \cdot 1 = 1 \mathop{\text{Bit}}$
 
 \smallskip
 
 -   4-seitiger Würfel:
     -   Entropie =
-        $H(\operatorname{Dice}) = -4\cdot(0.25 \log_2 0.25) = 2 \operatorname{Bit}$
+        $H(\mathop{\text{Dice}}) = -4\cdot(0.25 \log_2 0.25) = 2 \mathop{\text{Bit}}$
     -   Normierung:
         $1/(4\cdot 0.25 \log_2 (1/0.25)) = 1/(4\cdot 0.25 \cdot 2) = 0.5$
     -   Normierter Informationsgewinn:
-        $\operatorname{Gain}(S, A) \cdot \operatorname{Normalisation}(A) = 2 \operatorname{Bit} \cdot 0.5 = 1 \operatorname{Bit}$
+        $\mathop{\text{Gain}}(S, A) \cdot \mathop{\text{Normalisation}}(A) = 2 \mathop{\text{Bit}} \cdot 0.5 = 1 \mathop{\text{Bit}}$
 
 \bigskip
 
 =\> Normierung sorgt für fairen Vergleich der Attribute
 
 ::: notes
-*Anmerkung*: Auch hier ist die Entropie natürlich kein $\operatorname{Gain}(S, A)$.
+*Anmerkung*: Auch hier ist die Entropie natürlich kein $\mathop{\text{Gain}}(S, A)$.
 Das Beispiel soll nur übersichtlich deutlich machen, dass der "Vorteil" von
 Attributen mit mehr Ausprägungen durch die Normierung in C4.5 aufgehoben wird.
 :::

--- a/lecture/games/games2-minimax.md
+++ b/lecture/games/games2-minimax.md
@@ -45,7 +45,7 @@ wird dann im Spielbaum nach oben gereicht.
 
     =\> Startzustand und anwendbare Aktionen definieren den Zustandsraum.
 
--   Nutzenfunktion: $\operatorname{UTILITY}(s,p)$: Wert des Spiels für Spieler $p$
+-   Nutzenfunktion: $\mathop{\text{UTILITY}}(s,p)$: Wert des Spiels für Spieler $p$
     im Spielzustand $s$
 
 -   Strategie: Spieler benötigen **Strategie**, um zu gewünschtem Endzustand zu

--- a/lecture/games/games3-heuristics.md
+++ b/lecture/games/games3-heuristics.md
@@ -56,7 +56,7 @@ Minimax-Prinzip ausgewertet wird (=\> *Expectimax*).
 \smallskip
 
 -   Nutzung gewichteter Features $f_i$:
-    `\quad`{=tex}$\operatorname{Eval}(s) = w_1f_1(s) + w_2f_2(s) + \ldots$
+    `\quad`{=tex}$\mathop{\text{Eval}}(s) = w_1f_1(s) + w_2f_2(s) + \ldots$
 
     -   [Beispiel:]{.notes} $w_1 = 9$ und $f_1(s)$ = (# weiße Königinnen) - (#
         schwarze Königinnen)
@@ -64,7 +64,7 @@ Minimax-Prinzip ausgewertet wird (=\> *Expectimax*).
 \bigskip
 
 -   **Alternativ**: Speicherung von Positionen plus Bewertung in Datenbanken
-    `\newline`{=tex} =\> Lookup mit $\operatorname{Eval}(s)$ [(statt Berechnung zur
+    `\newline`{=tex} =\> Lookup mit $\mathop{\text{Eval}}(s)$ [(statt Berechnung zur
     Laufzeit)]{.notes}
 
 # Minimax mit mehreren Spielern
@@ -129,7 +129,7 @@ einen Ausgang, an dem die Wahrscheinlichkeit $P(i)$ dieses Ausgangs annotiert wi
 
 Expectimax-Wert für Zufallsknoten $C$:
 
-$$    \operatorname{Expectimax}(C) = \sum_i P(i) \operatorname{Expectimax}(s_i)$$
+$$    \mathop{\text{Expectimax}}(C) = \sum_i P(i) \mathop{\text{Expectimax}}(s_i)$$
 
 \bigskip
 

--- a/lecture/intro/intro2-problemsolving.md
+++ b/lecture/intro/intro2-problemsolving.md
@@ -168,7 +168,7 @@ Ein Problem besteht aus:
 :   Menge $S_A \subset S$
 
 **Aktionen**
-:   Menge von Funktionen $\operatorname{op}: S \to S$
+:   Menge von Funktionen $\mathop{\text{op}}: S \to S$
 
 **Zustandsraum**
 :   Menge aller Zustände $S$, die durch (wiederholte) Anwendung von Aktionen von den
@@ -177,10 +177,10 @@ Ein Problem besteht aus:
 \bigskip
 
 **Zieltest**
-:   Funktion $\operatorname{goal}: S \to \{0,1\}$
+:   Funktion $\mathop{\text{goal}}: S \to \{0,1\}$
 
 **Zielzustände**
-:   Menge $S_E \subseteq S$ mit $\forall x \in S_E : \operatorname{goal}(x)=1$
+:   Menge $S_E \subseteq S$ mit $\forall x \in S_E : \mathop{\text{goal}}(x)=1$
 
 \bigskip
 

--- a/lecture/naivebayes/nb2-naivebayes.md
+++ b/lecture/naivebayes/nb2-naivebayes.md
@@ -9,8 +9,8 @@ Dazu werden beim "Training" die bedingten Wahrscheinlichkeiten aus den
 Trainingsdaten geschätzt. Die Anwendung (Klassifikation) erfolgt dann durch die
 Nutzung der beim "Training" berechneten bedingten Wahrscheinlichkeiten:
 
-$$h_{MAP} = \operatorname{argmax}_{h \in H} P(h|D_1,  \ldots, D_n) =
-\operatorname{argmax}_{h \in H} P(h) \prod_i P(D_i|h)$$
+$$h_{MAP} = \mathop{\text{argmax}}_{h \in H} P(h|D_1,  \ldots, D_n) =
+\mathop{\text{argmax}}_{h \in H} P(h) \prod_i P(D_i|h)$$
 
 Für jede Hypothese $h$, d.h. für jede Klasse, wird der Posterior
 $P(h|D_1,  \ldots, D_n)$ ausgerechnet. Die Klasse, deren Wert dabei am höchsten ist,
@@ -102,8 +102,8 @@ Sie diesen auf die beiden Test-Dokumente an.
 \bigskip
 
 -   **Naive Bayes Klassifikator** bzw. **MAP** [("Maximum a Posteriori")]{.notes}
-    $$h_{MAP} = \operatorname{argmax}_{h \in H} P(h | D_1, \ldots, D_n)
-    = \operatorname{argmax}_{h \in H} P(h) \prod_i P(D_i | h)$$
+    $$h_{MAP} = \mathop{\text{argmax}}_{h \in H} P(h | D_1, \ldots, D_n)
+    = \mathop{\text{argmax}}_{h \in H} P(h) \prod_i P(D_i | h)$$
 
     ::: notes
     Naive Bayes: Wähle die plausibelste Hypothese, die von den Daten unterstützt
@@ -112,8 +112,8 @@ Sie diesen auf die beiden Test-Dokumente an.
 
 # Bayes'sches Lernen
 
-$$h_{MAP} = \operatorname{argmax}_{h \in H} P(h | D_1, \ldots, D_n)
-= \operatorname{argmax}_{h \in H} P(h) \prod_i P(D_i | h)$$
+$$h_{MAP} = \mathop{\text{argmax}}_{h \in H} P(h | D_1, \ldots, D_n)
+= \mathop{\text{argmax}}_{h \in H} P(h) \prod_i P(D_i | h)$$
 
 \bigskip
 
@@ -128,7 +128,7 @@ $$h_{MAP} = \operatorname{argmax}_{h \in H} P(h | D_1, \ldots, D_n)
 
 **Klassifikation**: Wähle wahrscheinlichste Klasse $h_{MAP}$ für Vektor $\mathbf{x}$
 
--   $h_{MAP} = \operatorname{argmax}_{h \in H} P(h) \prod_{x \in \mathbf{x}} P(x | h)$
+-   $h_{MAP} = \mathop{\text{argmax}}_{h \in H} P(h) \prod_{x \in \mathbf{x}} P(x | h)$
 
 # Beispiel Klassifikation mit NB
 
@@ -151,7 +151,7 @@ Gesucht: $P(\text{krank})$, $P(\text{gesund})$, $P(\text{Nase=0}|\text{krank})$,
 $P(\text{Nase=0}|\text{gesund})$, ...
 
 Wähle Klasse $$\begin{eqnarray}
-h_{MAP} = \operatorname{argmax}_{h \in \lbrace \text{gesund, krank} \rbrace} & P(h) \cdot P(\text{Nase=0}|h) \cdot P(\text{Husten=1}|h) \\
+h_{MAP} = \mathop{\text{argmax}}_{h \in \lbrace \text{gesund, krank} \rbrace} & P(h) \cdot P(\text{Nase=0}|h) \cdot P(\text{Husten=1}|h) \\
     & \cdot P(\text{Haut=0}|h) \cdot P(\text{Fieber=1}|h)
 \end{eqnarray}$$
 
@@ -200,8 +200,8 @@ die restlichen müssten aber auch beim "Training" berechnet werden!)
     \smallskip
 
     -   Likelihood der Daten (Terme):
-        -   $P(t|c) = \dfrac{\operatorname{count}(t,c)}{\sum_{v \in V} \operatorname{count}(v,c)}$
-            `\newline`{=tex} mit $\operatorname{count}(t,c)$ Anzahl der Vorkommen
+        -   $P(t|c) = \dfrac{\mathop{\text{count}}(t,c)}{\sum_{v \in V} \mathop{\text{count}}(v,c)}$
+            `\newline`{=tex} mit $\mathop{\text{count}}(t,c)$ Anzahl der Vorkommen
             von Term $t$ in allen Dokumenten der Klasse $c$ und $V$ die Vereinigung
             aller Terme aller Dokumente (als Menge)
 
@@ -209,7 +209,7 @@ die restlichen müssten aber auch beim "Training" berechnet werden!)
 
         ::: notes
         -   Variante mit Laplace-Glättung (s.u.):
-            $P(t|c) = \dfrac{\operatorname{count}(t,c) + 1}{\sum_{v \in V} \operatorname{count}(v,c) + |V|}$
+            $P(t|c) = \dfrac{\mathop{\text{count}}(t,c) + 1}{\sum_{v \in V} \mathop{\text{count}}(v,c) + |V|}$
         :::
 
 ::: slides
@@ -282,9 +282,9 @@ Trainingsmenge zu hoch gewichtet werden.
     Erinnerung: $\log(x \cdot y) = \log(x) + \log(y)$ und Logarithmus streng monoton
 
     $$\begin{eqnarray}
-    h_{MAP} &=& \operatorname{argmax}_{h \in H} P(h|D_1, \ldots, D_n) \\[5pt]
-            &=& \operatorname{argmax}_{h \in H} P(h) \prod_i P(D_i | h) \\[5pt]
-            &=& \operatorname{argmax}_{h \in H} [\log(P(h)) + \sum_i \log(P(D_i | h))]
+    h_{MAP} &=& \mathop{\text{argmax}}_{h \in H} P(h|D_1, \ldots, D_n) \\[5pt]
+            &=& \mathop{\text{argmax}}_{h \in H} P(h) \prod_i P(D_i | h) \\[5pt]
+            &=& \mathop{\text{argmax}}_{h \in H} [\log(P(h)) + \sum_i \log(P(D_i | h))]
     \end{eqnarray}$$
 :::
 
@@ -292,15 +292,15 @@ Trainingsmenge zu hoch gewichtet werden.
 # Maximum Likelihood
 
 -   **Maximum a Posteriori**
-    $$h_{MAP} = \operatorname{argmax}_{h \in H} P(h | D_1, \ldots, D_n)
-    = \operatorname{argmax}_{h \in H} P(h) \prod_i P(D_i | h)$$
+    $$h_{MAP} = \mathop{\text{argmax}}_{h \in H} P(h | D_1, \ldots, D_n)
+    = \mathop{\text{argmax}}_{h \in H} P(h) \prod_i P(D_i | h)$$
 
 \bigskip
 
 -   Annahme: Klassen uniform verteilt =\> $P(h_i) = P(h_j)$
 
     **Maximum Likelihood**
-    $$h_{ML} = \operatorname{argmax}_{h \in H} \prod_i P(D_i | h)$$
+    $$h_{ML} = \mathop{\text{argmax}}_{h \in H} \prod_i P(D_i | h)$$
 
     =\> Maximiere die Likelihood der Daten
 :::


### PR DESCRIPTION
see #439